### PR TITLE
bitset corruption after serialize/deserialize

### DIFF
--- a/javaewah/EWAHCompressedBitmap.java
+++ b/javaewah/EWAHCompressedBitmap.java
@@ -992,7 +992,11 @@ public class EWAHCompressedBitmap implements Cloneable, Externalizable, Iterable
     }
 
     public void	readExternal(ObjectInput in) throws IOException {
-        this.sizeinbits = in.readInt();
+        deserialize(in);
+    }
+    
+    public void deserialize(DataInput in) throws IOException {
+    	this.sizeinbits = in.readInt();
         this.actualsizeinwords = in.readInt();
         this.buffer = new long[in.readInt()];
         for(int k = 0; k< this.actualsizeinwords; ++k)
@@ -1001,7 +1005,11 @@ public class EWAHCompressedBitmap implements Cloneable, Externalizable, Iterable
     }
 
     public void	writeExternal(ObjectOutput out) throws IOException  {
-        out.writeInt(this.sizeinbits);
+        serialize(out);
+    }
+    
+    public void serialize(DataOutput out) throws IOException {
+    	out.writeInt(this.sizeinbits);
         out.writeInt(this.actualsizeinwords);
         out.writeInt(this.buffer.length);
         for(int k = 0; k< this.actualsizeinwords; ++k)


### PR DESCRIPTION
Bitsets can become corrupted after serialization and then deserialization if the position of the RunningLengthWord is not at actualsizeinwords - 1, which is the default for deserialization.  The solution is to serialize and deserialize the RLW position.
