### PR TITLE
Nested Class NonEmptyException

### DIFF
--- a/src/main/java/com/googlecode/javaewah/NonEmptyVirtualStorage.java
+++ b/src/main/java/com/googlecode/javaewah/NonEmptyVirtualStorage.java
@@ -14,9 +14,23 @@ package com.googlecode.javaewah;
  * 
  */
 public class NonEmptyVirtualStorage implements BitmapStorage {
-  class NonEmptyException extends RuntimeException {
+  static class NonEmptyException extends RuntimeException {
     private static final long serialVersionUID = 1L;
+    
+    /**
+     * Do not fill in the stack trace for this exception
+     * for performance reasons.
+     *
+     * @return this instance
+     * @see java.lang.Throwable#fillInStackTrace()
+     */
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
   }
+  
+  private static final NonEmptyException nonEmptyException = new NonEmptyException();
 
   /**
    * If the word to be added is non-zero, a NonEmptyException exception is
@@ -26,7 +40,7 @@ public class NonEmptyVirtualStorage implements BitmapStorage {
    */
   public void add(long newdata) {
     if (newdata != 0)
-      throw new NonEmptyException();
+      throw nonEmptyException;
     return;
   }
 
@@ -37,7 +51,7 @@ public class NonEmptyVirtualStorage implements BitmapStorage {
    */
   public void addStreamOfLiteralWords(long[] data, int start, int number) {
       if(number>0){
-          throw new NonEmptyException();
+          throw nonEmptyException;
       }
   }
 
@@ -49,7 +63,7 @@ public class NonEmptyVirtualStorage implements BitmapStorage {
    */
   public void addStreamOfEmptyWords(boolean v, long number) {
     if (v && (number>0))
-      throw new NonEmptyException();
+      throw nonEmptyException;
     return;
   }
 
@@ -61,7 +75,7 @@ public class NonEmptyVirtualStorage implements BitmapStorage {
    */
   public void addStreamOfNegatedLiteralWords(long[] data, int start, int number) {
       if(number>0){
-          throw new NonEmptyException();
+          throw nonEmptyException;
       }
   }
 

--- a/src/main/java/com/googlecode/javaewah32/NonEmptyVirtualStorage32.java
+++ b/src/main/java/com/googlecode/javaewah32/NonEmptyVirtualStorage32.java
@@ -1,6 +1,7 @@
 package com.googlecode.javaewah32;
 
 
+
 /*
  * Copyright 2009-2012, Daniel Lemire, Cliff Moon, David McIntosh and Robert Becho
  * Licensed under APL 2.0.
@@ -16,14 +17,30 @@ package com.googlecode.javaewah32;
  */
 public class NonEmptyVirtualStorage32 implements BitmapStorage32 {
   static class NonEmptyException extends RuntimeException {
-    private static final long serialVersionUID = 1L;    
+    private static final long serialVersionUID = 1L;  
+    
+    /**
+     * Do not fill in the stack trace for this exception
+     * for performance reasons.
+     *
+     * @return this instance
+     * @see java.lang.Throwable#fillInStackTrace()
+     */
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
   }
+  
+  private static final NonEmptyException nonEmptyException = new NonEmptyException();
+  
+  
   /**
    * If the word to be added is non-zero, a NonEmptyException exception is thrown.
    * @see com.googlecode.javaewah.BitmapStorage#add(int)
    */
   public void add(int newdata) {
-    if(newdata!=0) throw new NonEmptyException(); 
+    if(newdata!=0) throw nonEmptyException; 
   }
 
   /**
@@ -33,7 +50,7 @@ public class NonEmptyVirtualStorage32 implements BitmapStorage32 {
    */
   public void addStreamOfLiteralWords(int[] data, int start, int number) {
     if (number > 0){
-      throw new NonEmptyException();
+      throw nonEmptyException;
     }
   }
 
@@ -44,7 +61,7 @@ public class NonEmptyVirtualStorage32 implements BitmapStorage32 {
    * @see com.googlecode.javaewah.BitmapStorage#addStreamOfEmptyWords(boolean, int)
    */
   public void addStreamOfEmptyWords(boolean v, int number) {
-    if(v && (number>0)) throw new NonEmptyException(); 
+    if(v && (number>0)) throw nonEmptyException; 
   }
 
   /**
@@ -54,7 +71,7 @@ public class NonEmptyVirtualStorage32 implements BitmapStorage32 {
    */
   public void addStreamOfNegatedLiteralWords(int[] data, int start, int number) {
     if (number > 0){
-      throw new NonEmptyException();
+      throw nonEmptyException;
     }
   }
 


### PR DESCRIPTION
I changed the Nested Class NonEmptyException to be static, to avoid the creation overhead of an Exception Object on each NonEmptyVirtualStorage32 instance. This speeds up EWAHCompressedBitmap.equals() dramatically.
