### PR TITLE
Bitmaps composition

### DIFF
--- a/src/main/java/com/googlecode/javaewah/EWAHCompressedBitmap.java
+++ b/src/main/java/com/googlecode/javaewah/EWAHCompressedBitmap.java
@@ -1574,6 +1574,57 @@ public final class EWAHCompressedBitmap implements Cloneable, Externalizable,
     }
 
     /**
+     * Returns a new compressed bitmap containing the composition of
+     * the current bitmap with some other bitmap.
+     *
+     * If you are not planning on adding to the resulting bitmap, you may
+     * call the trim() method to reduce memory usage.
+     *
+     * The current bitmap is not modified.
+     *
+     * @param a the other bitmap (it will not be modified)
+     * @return the EWAH compressed bitmap
+     */
+    @Override
+    public EWAHCompressedBitmap compose(EWAHCompressedBitmap a) {
+        int size = this.actualSizeInWords;
+        final EWAHCompressedBitmap container = new EWAHCompressedBitmap(size);
+        composeToContainer(a, container);
+        return container;
+    }
+
+    /**
+     * Computes a new compressed bitmap containing the composition of
+     * the current bitmap with some other bitmap.
+     *
+     * The current bitmap is not modified.
+     *
+     * The content of the container is overwritten.
+     *
+     * @param a         the other bitmap (it will not be modified)
+     * @param container where we store the result
+     */
+    public void composeToContainer(final EWAHCompressedBitmap a,
+                                   final EWAHCompressedBitmap container) {
+        container.clear();
+        final IntIterator i = a.intIterator();
+        final IntIterator j = intIterator();
+        int index = 0;
+        while(i.hasNext() && j.hasNext()) {
+            int iPosition = i.next();
+            while(j.hasNext()) {
+                int jPosition = j.next();
+                if(iPosition == index++) {
+                    //consecutive ones could be optimized
+                    container.set(jPosition);
+                    break;
+                }
+            }
+        }
+        container.setSizeInBits(sizeInBits, false);
+    }
+
+    /**
      * For internal use. Computes the bitwise and of the provided bitmaps
      * and stores the result in the container.
      * 

--- a/src/main/java/com/googlecode/javaewah/LogicalElement.java
+++ b/src/main/java/com/googlecode/javaewah/LogicalElement.java
@@ -40,7 +40,7 @@ public interface LogicalElement<T> {
      * @param le another element
      * @return the result of the operation
      */
-    LogicalElement or(T le);
+    T or(T le);
 
     /**
      * How many logical bits does this element represent?
@@ -61,7 +61,15 @@ public interface LogicalElement<T> {
      * Compute the bitwise logical Xor
      *
      * @param le element
-     * @return the results of the operation
+     * @return the result of the operation
      */
     T xor(T le);
+
+    /**
+     * Compute the composition
+     *
+     * @param le another element
+     * @return the result of the operation
+     */
+    T compose(T le);
 }

--- a/src/main/java/com/googlecode/javaewah32/EWAHCompressedBitmap32.java
+++ b/src/main/java/com/googlecode/javaewah32/EWAHCompressedBitmap32.java
@@ -1636,6 +1636,57 @@ public final class EWAHCompressedBitmap32 implements Cloneable, Externalizable,
     }
 
     /**
+     * Returns a new compressed bitmap containing the composition of
+     * the current bitmap with some other bitmap.
+     *
+     * If you are not planning on adding to the resulting bitmap, you may
+     * call the trim() method to reduce memory usage.
+     *
+     * The current bitmap is not modified.
+     *
+     * @param a the other bitmap (it will not be modified)
+     * @return the EWAH compressed bitmap
+     */
+    @Override
+    public EWAHCompressedBitmap32 compose(EWAHCompressedBitmap32 a) {
+        int size = this.actualSizeInWords;
+        final EWAHCompressedBitmap32 container = new EWAHCompressedBitmap32(size);
+        composeToContainer(a, container);
+        return container;
+    }
+
+    /**
+     * Computes a new compressed bitmap containing the composition of
+     * the current bitmap with some other bitmap.
+     *
+     * The current bitmap is not modified.
+     *
+     * The content of the container is overwritten.
+     *
+     * @param a         the other bitmap (it will not be modified)
+     * @param container where we store the result
+     */
+    public void composeToContainer(final EWAHCompressedBitmap32 a,
+                                   final EWAHCompressedBitmap32 container) {
+        container.clear();
+        final IntIterator i = a.intIterator();
+        final IntIterator j = intIterator();
+        int index = 0;
+        while(i.hasNext() && j.hasNext()) {
+            int iPosition = i.next();
+            while(j.hasNext()) {
+                int jPosition = j.next();
+                if(iPosition == index++) {
+                    //consecutive ones could be optimized
+                    container.set(jPosition);
+                    break;
+                }
+            }
+        }
+        container.setSizeInBits(sizeInBits, false);
+    }
+
+    /**
      * For internal use. Computes the bitwise and of the provided bitmaps
      * and stores the result in the container.
      * 

--- a/src/test/java/com/googlecode/javaewah/EWAHCompressedBitmapTest.java
+++ b/src/test/java/com/googlecode/javaewah/EWAHCompressedBitmapTest.java
@@ -12,11 +12,81 @@ import org.junit.Test;
 import java.io.*;
 import java.util.*;
 
+import static com.googlecode.javaewah.EWAHCompressedBitmap.WORD_IN_BITS;
+
 /**
  * This class is used for basic unit testing.
  */
 @SuppressWarnings("javadoc")
 public class EWAHCompressedBitmapTest {
+
+    @Test
+    public void simpleCompose() {
+        EWAHCompressedBitmap bitmap1 = EWAHCompressedBitmap.bitmapOf(1, 3, 4);
+        bitmap1.setSizeInBits(5, false);
+
+        EWAHCompressedBitmap bitmap2 = EWAHCompressedBitmap.bitmapOf(0, 2);
+
+        EWAHCompressedBitmap result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(5, result.sizeInBits());
+        Assert.assertEquals(2, result.cardinality());
+        Assert.assertEquals(Integer.valueOf(1), result.toList().get(0));
+        Assert.assertEquals(Integer.valueOf(4), result.toList().get(1));
+    }
+
+    @Test
+    public void composeBitmapOfOnesWithItself() {
+        EWAHCompressedBitmap bitmap = EWAHCompressedBitmap.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap result = bitmap.compose(bitmap);
+
+        Assert.assertEquals(bitmap, result);
+    }
+
+    @Test
+    public void composeBitmapOfZerosAndOnesWithBitmapOfOnes() {
+        EWAHCompressedBitmap bitmap1 = EWAHCompressedBitmap.bitmapOf();
+        bitmap1.setSizeInBits(WORD_IN_BITS, false);
+        bitmap1.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap bitmap2 = EWAHCompressedBitmap.bitmapOf();
+        bitmap2.setSizeInBits(WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(bitmap1, result);
+    }
+
+    @Test
+    public void composeBitmapOfOnesWithBitmapOfZerosAndOnes() {
+        EWAHCompressedBitmap bitmap1 = EWAHCompressedBitmap.bitmapOf();
+        bitmap1.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap bitmap2 = EWAHCompressedBitmap.bitmapOf();
+        bitmap2.setSizeInBits(WORD_IN_BITS, false);
+        bitmap2.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(bitmap2, result);
+    }
+
+    @Test
+    public void composeBitmapWithBitmapOfZeros() {
+        EWAHCompressedBitmap bitmap1 = EWAHCompressedBitmap.bitmapOf(1, 3, 4, 9);
+        bitmap1.setSizeInBits(WORD_IN_BITS, false);
+
+        EWAHCompressedBitmap bitmap2 = EWAHCompressedBitmap.bitmapOf();
+        bitmap2.setSizeInBits(5, false);
+
+        EWAHCompressedBitmap result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(0, result.cardinality());
+        Assert.assertEquals(WORD_IN_BITS, result.sizeInBits());
+    }
+
     @Test
     public void testAstesana() {
     	for(int k = 5; k < 256; ++k) {

--- a/src/test/java/com/googlecode/javaewah32/EWAHCompressedBitmap32Test.java
+++ b/src/test/java/com/googlecode/javaewah32/EWAHCompressedBitmap32Test.java
@@ -13,11 +13,80 @@ import org.junit.Test;
 import java.io.*;
 import java.util.*;
 
+import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;
+
 /**
  * This class is used for basic unit testing.
  */
 @SuppressWarnings("javadoc")
 public class EWAHCompressedBitmap32Test {
+
+    @Test
+    public void simpleCompose() {
+        EWAHCompressedBitmap32 bitmap1 = EWAHCompressedBitmap32.bitmapOf(1, 3, 4);
+        bitmap1.setSizeInBits(5, false);
+
+        EWAHCompressedBitmap32 bitmap2 = EWAHCompressedBitmap32.bitmapOf(0, 2);
+
+        EWAHCompressedBitmap32 result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(5, result.sizeInBits());
+        Assert.assertEquals(2, result.cardinality());
+        Assert.assertEquals(Integer.valueOf(1), result.toList().get(0));
+        Assert.assertEquals(Integer.valueOf(4), result.toList().get(1));
+    }
+
+    @Test
+    public void composeBitmapOfOnesWithItself() {
+        EWAHCompressedBitmap32 bitmap = EWAHCompressedBitmap32.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap32 result = bitmap.compose(bitmap);
+
+        Assert.assertEquals(bitmap, result);
+    }
+
+    @Test
+    public void composeBitmapOfZerosAndOnesWithBitmapOfOnes() {
+        EWAHCompressedBitmap32 bitmap1 = EWAHCompressedBitmap32.bitmapOf();
+        bitmap1.setSizeInBits(WORD_IN_BITS, false);
+        bitmap1.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap32 bitmap2 = EWAHCompressedBitmap32.bitmapOf();
+        bitmap2.setSizeInBits(WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap32 result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(bitmap1, result);
+    }
+
+    @Test
+    public void composeBitmapOfOnesWithBitmapOfZerosAndOnes() {
+        EWAHCompressedBitmap32 bitmap1 = EWAHCompressedBitmap32.bitmapOf();
+        bitmap1.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap32 bitmap2 = EWAHCompressedBitmap32.bitmapOf();
+        bitmap2.setSizeInBits(WORD_IN_BITS, false);
+        bitmap2.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        EWAHCompressedBitmap32 result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(bitmap2, result);
+    }
+
+    @Test
+    public void composeBitmapWithBitmapOfZeros() {
+        EWAHCompressedBitmap32 bitmap1 = EWAHCompressedBitmap32.bitmapOf(1, 3, 4, 9);
+        bitmap1.setSizeInBits(WORD_IN_BITS, false);
+
+        EWAHCompressedBitmap32 bitmap2 = EWAHCompressedBitmap32.bitmapOf();
+        bitmap2.setSizeInBits(5, false);
+
+        EWAHCompressedBitmap32 result = bitmap1.compose(bitmap2);
+
+        Assert.assertEquals(0, result.cardinality());
+        Assert.assertEquals(WORD_IN_BITS, result.sizeInBits());
+    }
 
     @Test
 	public void testAstesana() {


### PR DESCRIPTION
This PR adds a new operation on bitmaps: bitmaps composition. Composition filters out the ones of a bitmap with another bitmap.

For example, if you have the following bitmap A = { 0, 1, 0, 1, 1, 0 } and want to keep only the second and third ones, you can call A.compose(B) with B = { 0, 1, 1 } and you will get C = { 0, 0, 0, 1, 1, 0 }.

The current implementation is very basic and just consists in iterating over bitmaps. So there is place for optimization, in particular with consecutive ones to keep.
