### PR TITLE
Implement composition using chunk iterators

### DIFF
--- a/src/main/java/com/googlecode/javaewah/ChunkIterator.java
+++ b/src/main/java/com/googlecode/javaewah/ChunkIterator.java
@@ -1,0 +1,48 @@
+package com.googlecode.javaewah;
+
+/*
+ * Copyright 2009-2014, Daniel Lemire, Cliff Moon, David McIntosh, Robert Becho, Google Inc., Veronika Zenz, Owen Kaser, Gregory Ssi-Yan-Kai, Rory Graves
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+/**
+ * The ChunkIterator interface is used to iterate over chunks of ones or zeros.
+ *
+ * @author Gregory Ssi-Yan-Kai
+ */
+public interface ChunkIterator {
+
+    /**
+     * Is there more?
+     *
+     * @return true, if there is more, false otherwise
+     */
+    boolean hasNext();
+
+    /**
+     * Return the next bit
+     *
+     * @return the bit
+     */
+    boolean nextBit();
+
+    /**
+     * Return the length of the next bit
+     *
+     * @return the length
+     */
+    int nextLength();
+
+    /**
+     * Move the iterator at the next different bit
+     */
+    void move();
+
+    /**
+     * Move the iterator at the next ith bit
+     *
+     * @param bits  the number of bits to skip
+     */
+    void move(int bits);
+
+}

--- a/src/main/java/com/googlecode/javaewah/ChunkIteratorImpl.java
+++ b/src/main/java/com/googlecode/javaewah/ChunkIteratorImpl.java
@@ -1,0 +1,157 @@
+package com.googlecode.javaewah;
+
+/*
+ * Copyright 2009-2014, Daniel Lemire, Cliff Moon, David McIntosh, Robert Becho, Google Inc., Veronika Zenz, Owen Kaser, Gregory Ssi-Yan-Kai, Rory Graves
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import static com.googlecode.javaewah.EWAHCompressedBitmap.WORD_IN_BITS;
+
+/**
+ * The ChunkIteratorImpl is the 64 bit implementation of the ChunkIterator
+ * interface, which efficiently returns the chunks of ones and zeros represented by an
+ * EWAHIterator.
+ *
+ * @author Gregory Ssi-Yan-Kai
+ */
+final class ChunkIteratorImpl implements ChunkIterator {
+
+    private final EWAHIterator ewahIter;
+    private final int sizeInBits;
+    private final long[] ewahBuffer;
+    private int position;
+    private boolean runningBit;
+    private int runningLength;
+    private long word;
+    private long wordMask;
+    private int wordPosition;
+    private int wordLength;
+    private boolean hasNext;
+    private Boolean nextBit;
+    private int nextLength;
+
+    ChunkIteratorImpl(EWAHIterator ewahIter, int sizeInBits) {
+        this.ewahIter = ewahIter;
+        this.sizeInBits = sizeInBits;
+        this.ewahBuffer = ewahIter.buffer();
+        this.hasNext = moveToNextRLW();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.hasNext;
+    }
+
+    @Override
+    public boolean nextBit() {
+        return this.nextBit;
+    }
+
+    @Override
+    public int nextLength() {
+        return this.nextLength;
+    }
+
+    @Override
+    public void move() {
+        move(this.nextLength);
+    }
+
+    @Override
+    public void move(int bits) {
+        this.nextLength -= bits;
+        if(this.nextLength <= 0) {
+            do {
+                this.nextBit = null;
+                updateNext();
+                this.hasNext = moveToNextRLW();
+            } while(this.nextLength < 0);
+        }
+    }
+
+    private boolean moveToNextRLW() {
+        while (!runningHasNext() && !literalHasNext()) {
+            if (!hasNextRLW()) {
+                return this.nextBit!=null;
+            }
+            setRLW(nextRLW());
+            updateNext();
+        }
+        return true;
+    }
+
+    private void setRLW(RunningLengthWord rlw) {
+        this.runningLength = Math.min(this.sizeInBits,
+                                      this.position + WORD_IN_BITS * (int) rlw.getRunningLength());
+        this.runningBit = rlw.getRunningBit();
+        this.wordPosition = this.ewahIter.literalWords();
+        this.wordLength = this.wordPosition + rlw.getNumberOfLiteralWords();
+    }
+
+    private boolean runningHasNext() {
+        return this.position < this.runningLength;
+    }
+
+    private boolean literalHasNext() {
+        while (this.word == 0 && this.wordPosition < this.wordLength) {
+            this.word = this.ewahBuffer[this.wordPosition++];
+            if (this.wordPosition == this.wordLength && !hasNextRLW()) {
+                final int usedBitsInLast = this.sizeInBits % WORD_IN_BITS;
+                if (usedBitsInLast > 0) {
+                    this.word &= ((~0l) >>> (WORD_IN_BITS - usedBitsInLast));
+                }
+            }
+            this.wordMask = 1l;
+        }
+        return this.word != 0 || (!hasNextRLW() && this.position < this.sizeInBits);
+    }
+
+    private boolean hasNextRLW() {
+        return this.ewahIter.hasNext();
+    }
+
+    private RunningLengthWord nextRLW() {
+        return this.ewahIter.next();
+    }
+
+    private void updateNext() {
+        if(runningHasNext()) {
+            if(this.nextBit == null || this.nextBit == this.runningBit) {
+                this.nextBit = this.runningBit;
+                int offset = runningOffset();
+                this.nextLength += offset;
+                movePosition(offset);
+                updateNext();
+            }
+        } else if (literalHasNext()) {
+            boolean b = currentWordBit();
+            if(this.nextBit == null || this.nextBit == b) {
+                this.nextBit = b;
+                this.nextLength++;
+                movePosition(1);
+                shiftWordMask();
+                updateNext();
+            }
+        } else {
+            moveToNextRLW();
+        }
+    }
+
+    private int runningOffset() {
+        return this.runningLength - this.position;
+    }
+
+    private void movePosition(int offset) {
+        this.position += offset;
+    }
+
+    private boolean currentWordBit() {
+        return (this.word & this.wordMask) != 0;
+    }
+
+    private void shiftWordMask() {
+        this.word &= ~this.wordMask;
+        this.wordMask = this.wordMask << 1;
+    }
+
+}

--- a/src/main/java/com/googlecode/javaewah32/ChunkIteratorImpl32.java
+++ b/src/main/java/com/googlecode/javaewah32/ChunkIteratorImpl32.java
@@ -1,0 +1,159 @@
+package com.googlecode.javaewah32;
+
+/*
+ * Copyright 2009-2014, Daniel Lemire, Cliff Moon, David McIntosh, Robert Becho, Google Inc., Veronika Zenz, Owen Kaser, Gregory Ssi-Yan-Kai, Rory Graves
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import com.googlecode.javaewah.ChunkIterator;
+
+import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;
+
+/**
+ * The ChunkIteratorImpl is the 32 bit implementation of the ChunkIterator
+ * interface, which efficiently returns the chunks of ones and zeros represented by an
+ * EWAHIterator.
+ *
+ * @author Gregory Ssi-Yan-Kai
+ */
+final class ChunkIteratorImpl32 implements ChunkIterator {
+
+    private final EWAHIterator32 ewahIter;
+    private final int sizeInBits;
+    private final int[] ewahBuffer;
+    private int position;
+    private boolean runningBit;
+    private int runningLength;
+    private int word;
+    private int wordMask;
+    private int wordPosition;
+    private int wordLength;
+    private boolean hasNext;
+    private Boolean nextBit;
+    private int nextLength;
+
+    ChunkIteratorImpl32(EWAHIterator32 ewahIter, int sizeInBits) {
+        this.ewahIter = ewahIter;
+        this.sizeInBits = sizeInBits;
+        this.ewahBuffer = ewahIter.buffer();
+        this.hasNext = moveToNextRLW();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.hasNext;
+    }
+
+    @Override
+    public boolean nextBit() {
+        return this.nextBit;
+    }
+
+    @Override
+    public int nextLength() {
+        return this.nextLength;
+    }
+
+    @Override
+    public void move() {
+        move(this.nextLength);
+    }
+
+    @Override
+    public void move(int bits) {
+        this.nextLength -= bits;
+        if(this.nextLength <= 0) {
+            do {
+                this.nextBit = null;
+                updateNext();
+                this.hasNext = moveToNextRLW();
+            } while(this.nextLength < 0);
+        }
+    }
+
+    private boolean moveToNextRLW() {
+        while (!runningHasNext() && !literalHasNext()) {
+            if (!hasNextRLW()) {
+                return this.nextBit!=null;
+            }
+            setRLW(nextRLW());
+            updateNext();
+        }
+        return true;
+    }
+
+  private void setRLW(RunningLengthWord32 rlw) {
+        this.runningLength = Math.min(this.sizeInBits,
+                                      this.position + WORD_IN_BITS * rlw.getRunningLength());
+        this.runningBit = rlw.getRunningBit();
+        this.wordPosition = this.ewahIter.literalWords();
+        this.wordLength = this.wordPosition + rlw.getNumberOfLiteralWords();
+    }
+
+    private boolean runningHasNext() {
+        return this.position < this.runningLength;
+    }
+
+    private boolean literalHasNext() {
+        while (this.word == 0 && this.wordPosition < this.wordLength) {
+            this.word = this.ewahBuffer[this.wordPosition++];
+            if (this.wordPosition == this.wordLength && !hasNextRLW()) {
+                final int usedBitsInLast = this.sizeInBits % WORD_IN_BITS;
+                if (usedBitsInLast > 0) {
+                    this.word &= ((~0) >>> (WORD_IN_BITS - usedBitsInLast));
+                }
+            }
+            this.wordMask = 1;
+        }
+        return this.word != 0 || (!hasNextRLW() && this.position < this.sizeInBits);
+    }
+
+    private boolean hasNextRLW() {
+        return this.ewahIter.hasNext();
+    }
+
+    private RunningLengthWord32 nextRLW() {
+        return this.ewahIter.next();
+    }
+
+    private void updateNext() {
+        if(runningHasNext()) {
+            if(this.nextBit == null || this.nextBit == this.runningBit) {
+                this.nextBit = this.runningBit;
+                int offset = runningOffset();
+                this.nextLength += offset;
+                movePosition(offset);
+                updateNext();
+            }
+        } else if (literalHasNext()) {
+            boolean b = currentWordBit();
+            if(this.nextBit == null || this.nextBit == b) {
+                this.nextBit = b;
+                this.nextLength++;
+                movePosition(1);
+                shiftWordMask();
+                updateNext();
+            }
+        } else {
+            moveToNextRLW();
+        }
+    }
+
+    private int runningOffset() {
+        return this.runningLength - this.position;
+    }
+
+    private void movePosition(int offset) {
+        this.position += offset;
+    }
+
+    private boolean currentWordBit() {
+        return (this.word & this.wordMask) != 0;
+    }
+
+    private void shiftWordMask() {
+        this.word &= ~this.wordMask;
+        this.wordMask = this.wordMask << 1;
+    }
+
+}

--- a/src/main/java/com/googlecode/javaewah32/ClearIntIterator32.java
+++ b/src/main/java/com/googlecode/javaewah32/ClearIntIterator32.java
@@ -2,7 +2,7 @@ package com.googlecode.javaewah32;
 
 import com.googlecode.javaewah.IntIterator;
 
-import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;;
+import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;
 
 /*
  * Copyright 2009-2014, Daniel Lemire, Cliff Moon, David McIntosh, Robert Becho, Google Inc., Veronika Zenz, Owen Kaser, Gregory Ssi-Yan-Kai, Rory Graves

--- a/src/main/java/com/googlecode/javaewah32/IntIteratorImpl32.java
+++ b/src/main/java/com/googlecode/javaewah32/IntIteratorImpl32.java
@@ -7,7 +7,7 @@ package com.googlecode.javaewah32;
 
 import com.googlecode.javaewah.IntIterator;
 
-import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;;
+import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;
 
 /**
  * The IntIteratorImpl32 is the 32 bit implementation of the IntIterator

--- a/src/test/java/com/googlecode/javaewah/EWAHCompressedBitmapTest.java
+++ b/src/test/java/com/googlecode/javaewah/EWAHCompressedBitmapTest.java
@@ -21,6 +21,79 @@ import static com.googlecode.javaewah.EWAHCompressedBitmap.WORD_IN_BITS;
 public class EWAHCompressedBitmapTest {
 
     @Test
+    public void chunkIterator() {
+        EWAHCompressedBitmap bitmap = EWAHCompressedBitmap.bitmapOf(0, 1, 2, 3, 4, 7, 8, 9, 10);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(5, iterator.nextLength());
+        iterator.move(2);
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(3, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(2, iterator.nextLength());
+        iterator.move(5);
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(1, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfZeros() {
+        EWAHCompressedBitmap bitmap = EWAHCompressedBitmap.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS, false);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfZerosAndOnes() {
+        EWAHCompressedBitmap bitmap = EWAHCompressedBitmap.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS + 10, false);
+        bitmap.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS + 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS - 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfOnesAndZeros() {
+        EWAHCompressedBitmap bitmap = EWAHCompressedBitmap.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS - 10, true);
+        bitmap.setSizeInBits(2 * WORD_IN_BITS, false);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS - 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS + 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
     public void simpleCompose() {
         EWAHCompressedBitmap bitmap1 = EWAHCompressedBitmap.bitmapOf(1, 3, 4);
         bitmap1.setSizeInBits(5, false);

--- a/src/test/java/com/googlecode/javaewah32/EWAHCompressedBitmap32Test.java
+++ b/src/test/java/com/googlecode/javaewah32/EWAHCompressedBitmap32Test.java
@@ -5,6 +5,7 @@ package com.googlecode.javaewah32;
  * Licensed under the Apache License, Version 2.0.
  */
 
+import com.googlecode.javaewah.ChunkIterator;
 import com.googlecode.javaewah.FastAggregation;
 import com.googlecode.javaewah.IntIterator;
 import org.junit.Assert;
@@ -20,6 +21,79 @@ import static com.googlecode.javaewah32.EWAHCompressedBitmap32.WORD_IN_BITS;
  */
 @SuppressWarnings("javadoc")
 public class EWAHCompressedBitmap32Test {
+
+    @Test
+    public void chunkIterator() {
+        EWAHCompressedBitmap32 bitmap = EWAHCompressedBitmap32.bitmapOf(0, 1, 2, 3, 4, 7, 8, 9, 10);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(5, iterator.nextLength());
+        iterator.move(2);
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(3, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(2, iterator.nextLength());
+        iterator.move(5);
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(1, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfZeros() {
+        EWAHCompressedBitmap32 bitmap = EWAHCompressedBitmap32.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS, false);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfZerosAndOnes() {
+        EWAHCompressedBitmap32 bitmap = EWAHCompressedBitmap32.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS + 10, false);
+        bitmap.setSizeInBits(2 * WORD_IN_BITS, true);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS + 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS - 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void chunkIteratorOverBitmapOfOnesAndZeros() {
+        EWAHCompressedBitmap32 bitmap = EWAHCompressedBitmap32.bitmapOf();
+        bitmap.setSizeInBits(WORD_IN_BITS - 10, true);
+        bitmap.setSizeInBits(2 * WORD_IN_BITS, false);
+
+        ChunkIterator iterator = bitmap.chunkIterator();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertTrue(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS - 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertTrue(iterator.hasNext());
+        Assert.assertFalse(iterator.nextBit());
+        Assert.assertEquals(WORD_IN_BITS + 10, iterator.nextLength());
+        iterator.move();
+        Assert.assertFalse(iterator.hasNext());
+    }
 
     @Test
     public void simpleCompose() {


### PR DESCRIPTION
This PR introduces a new kind of iterators over bitmap: chunk iterators. When it traverses a bitmap, a chunk iterator gives the value of the bit it is pointing to (true or false) and the number of consecutive bits with the same value.

For example, with the bitmap A = { 1, 1, 0, 0, 0, 1 }, the chunk iterator will give successively (true, 2), (false, 3), (true, 1).

Note that it is possible to skip an arbitrary number of bits at any position. In the above example, if the chunk iterator is pointing to the third bit, it returns (false, 3). It can then be moved to the second following bit and it will return (false, 1).

Finally, bitmap composition implementation has been adapted to use chunk iterators.
