### PR TITLE
using DirectByteBuffers fails when running in java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
   <version>1.1.13-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <encoding>UTF-8</encoding>
   </properties>
   <licenses>
@@ -71,6 +70,25 @@
                 <reuseForks>true</reuseForks>
                 <argLine>-Xmx1024m</argLine>
             </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>11</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,25 +72,6 @@
             </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-            <configuration>
-              <toolchains>
-                <jdk>
-                  <version>11</version>
-                </jdk>
-              </toolchains>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>2.3.7</version>


### PR DESCRIPTION
Due to the overloaded ByteBuffer.position(int) method and the jar compiled with a jdk > 8, the 1.1.12 version of javaewah will cause a NoSuchMethodException when running in java 8. This can be verified by adding <jvm>/path/to/java8</jvm> to the surefire plugin's configuration when the code is compiled with jdk9 or above. The following blog post provides more details about what's happening and how the compiler.release version makes a difference compared to compiler.source and compiler.target: https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/.